### PR TITLE
Threads

### DIFF
--- a/app/src/main/java/com/brouken/palabre/ttrss/TinyExtension.java
+++ b/app/src/main/java/com/brouken/palabre/ttrss/TinyExtension.java
@@ -30,6 +30,8 @@ import java.util.Comparator;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
@@ -49,6 +51,12 @@ public class TinyExtension extends PalabreExtension {
     List<Integer> mCategories;
     List<Integer> mFeeds;
     int mLastArticleId;
+    float mProgress;
+
+    ExecutorService mExecutorService;
+    int mThreadCount = 1;
+    List<String> mUnreadArticleIds = new ArrayList<>();
+
 
     List<Source> mPreviousSources;
 
@@ -135,6 +143,8 @@ public class TinyExtension extends PalabreExtension {
         publishUpdateStatus(new ExtensionUpdateStatus().start());
 
         try {
+            mExecutorService = Executors.newFixedThreadPool(mThreadCount);
+
             mCategories = new ArrayList<>();
             mFeeds = new ArrayList<>();
 
@@ -211,67 +221,106 @@ public class TinyExtension extends PalabreExtension {
         processFeedsCleanup();
     }
 
-    float incrementProgress(float progress) {
-        publishUpdateStatus(new ExtensionUpdateStatus().progress(Math.round(progress)));
-        return progress;
+    void incrementProgress(float increment) {
+        mProgress += increment;
+        int displayProgress = Math.round(mProgress);
+        log("Progress:" + displayProgress);
+        publishUpdateStatus(new ExtensionUpdateStatus().progress(displayProgress));
+    }
+
+    float getTotalCount(JSONArray content) {
+        float count = 0;
+        try {
+            for (int i = 0; i < content.length(); i++) {
+                JSONObject feed = (JSONObject) content.get(i);
+                if (!feed.isNull("updated") && feed.isNull("kind")) {
+                    count += feed.getInt("counter");
+                }
+            }
+        } catch (Exception e) {
+            log(e.toString());
+        }
+        return count;
     }
 
     void getHeadlines() throws JSONException, InterruptedException, ExecutionException, TimeoutException {
         //log("getHeadlines");
 
         final boolean firstRun = mLastArticleId <= 0;
-        List<String> unreadArticleIds = new ArrayList<>();
         List<String> articleIds;
 
+        mUnreadArticleIds.clear();
+
         // Determine progress counter
-        float progress = 25;
+        //   First run
+        //     Each call to unread feed (unreadCount / ARTICLES_IN_RESPONSE)
+        //     Each grab of 10 of a feed (feedCount)
+        //   Subsequent runs
+        //     Each call to unread feed (unreadCount / ARTICLES_IN_RESPONSE)
+        //     Updating read/unread on existing articles (savedCount/500)
+        //     Pulling new articles ((totalCount - savedCount) / ARTICLES_IN_RESPONSE)
+        mProgress = 25;
         List<Article> savedArticles = Article.getAll(this);
         JSONObject unreadResponse = getResponse(buildUnreadCountRequestJSON());
         float unreadCount = unreadResponse.getJSONObject("content").getInt("unread");
+        JSONObject totalResponse = getResponse(buildTotalCountRequestJSON());
+        float totalCount = getTotalCount(totalResponse.getJSONArray("content"));
         float feedCount = mFeeds.size();
         float savedCount = savedArticles.size();
         float progressIncrease = 1;
         if (firstRun) {
-            // Progress is number of unread, feedCount
-            if (unreadCount > ARTICLES_IN_RESPONSE)
-                progressIncrease = (95 - progress) / ((unreadCount / ARTICLES_IN_RESPONSE) + feedCount);
-            else
-                progressIncrease = (95 - progress) + feedCount;
+            progressIncrease = (95 - mProgress) / ((unreadCount / ARTICLES_IN_RESPONSE) + feedCount);
         } else {
-            // Progress is number of unread, number of saved, number new articles (assume less than 200, so 1)
-            if (unreadCount > ARTICLES_IN_RESPONSE)
-                progressIncrease = (95 - progress) / ((unreadCount / ARTICLES_IN_RESPONSE) + (savedCount/1000) + 1);
-            else
-                progressIncrease = (95 - progress) + savedCount + 1;
+            progressIncrease = (95 - mProgress) / ((unreadCount / ARTICLES_IN_RESPONSE) + (savedCount/500) + ((totalCount - savedCount) / ARTICLES_IN_RESPONSE));
         }
-        log("Progress - pi:" + progressIncrease + " uc:" + unreadCount + " fc:" + feedCount + " sc:" + savedCount);
-
+        log("Progress - pi:" + progressIncrease + " uc:" + unreadCount + " fc:" + feedCount + " sc:" + savedCount + " tc:" + totalCount);
         // Get ids of all unread articles (also save them on first run)
         log("Fetching unread.");
-        int skip = 0;
         if (unreadCount > 0) {
-            do {
-                JSONObject response = getResponse(buildHeadlinesUnreadRequestJSON(skip, firstRun));
-                articleIds = processHeadlines(response.getJSONArray("content"), firstRun);
-                unreadArticleIds.addAll(articleIds);
-                skip += articleIds.size();
-                progress = incrementProgress(progress+progressIncrease);
-            } while (articleIds.size() > 0);
+            float numRuns = unreadCount / ARTICLES_IN_RESPONSE;
+            for (int i = 0; i < numRuns; i++) {
+                final int placement = i;
+                final float placementIncrease = progressIncrease;
+                mExecutorService.execute(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            int skip = placement * ARTICLES_IN_RESPONSE;
+                            log("Thread processing for: " + skip);
+                            JSONObject response = getResponse(buildHeadlinesUnreadRequestJSON(skip, firstRun));
+                            List<String> articleIds = processHeadlines(response.getJSONArray("content"), firstRun);
+                            mUnreadArticleIds.addAll(articleIds);
+                            skip += articleIds.size();
+                            incrementProgress(placementIncrease);
+                        } catch (Exception e) {
+                            log(e.toString());
+                        }
+                    }
+                });
+            }
+            mExecutorService.shutdown();
+            while (!mExecutorService.isTerminated()) { }
+            log("Thread processing complete.");
         }
         log("Finished fetching unread.");
 
         // Update read state of articles viewed outside
         if (!firstRun) {
             log("Updating read state.");
+            int count = 0;
             for (Article savedArticle : savedArticles) {
-                boolean isRead = !unreadArticleIds.contains(savedArticle.getUniqueId());
-                progress = incrementProgress(progress+progressIncrease);
+                boolean isRead = !mUnreadArticleIds.contains(savedArticle.getUniqueId());
 
                 if (savedArticle.isRead() == isRead)
                     continue;
 
                 savedArticle.setRead(isRead);
                 savedArticle.save(this);
+                count++;
+                if (count == 500) {
+                    incrementProgress(progressIncrease);
+                    count = 0;
+                }
             }
             log("Finished updating read state.");
         }
@@ -282,20 +331,20 @@ public class TinyExtension extends PalabreExtension {
             for (Integer feedId : mFeeds) {
                 JSONObject response = getResponse(buildHeadlinesFeedRequestJSON(feedId));
                 processHeadlines(response.getJSONArray("content"), true);
-                progress = incrementProgress(progress+progressIncrease);
+                incrementProgress(progressIncrease);
             }
             log("Finished grabbing 10 from each feed.");
         } else {
             // Get all new articles since previous sync
             log("Getting new articles since previous sync.");
-            skip = 0;
+            int skip = 0;
             do {
                 // TODO: We grabbed all unread articles before, this is just going to overlap those with the read articles, too. Perhaps change to read?
                 JSONObject response = getResponse(buildHeadlinesRequestJSON(skip));
                 articleIds = processHeadlines(response.getJSONArray("content"), true);
                 skip += articleIds.size();
+                incrementProgress(progressIncrease);
             } while (articleIds.size() > 0);
-            progress = incrementProgress(progress+progressIncrease);
             log("Finished getting new articles since previous sync.");
         }
     }
@@ -330,6 +379,15 @@ public class TinyExtension extends PalabreExtension {
         json.put("op", "getUnread");
         json.put("sid", mSid);
         //log("curl -d '" + json.toString() + "' " + mUrlApi + " > /tmp/ttrss/buildUnreadCountRequestJSON.json");
+        return json;
+    }
+
+    JSONObject buildTotalCountRequestJSON() throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("op", "getCounters");
+        json.put("sid", mSid);
+        json.put("output_mode", "f");
+        //log("curl -d '" + json.toString() + "' " + mUrlApi + " > /tmp/ttrss/buildTotalCountRequestJSON.json");
         return json;
     }
 


### PR DESCRIPTION
Ok, I lied, one more. This one adds in threading, so that instead of pulling feeds one at a time and unread 200 at a time, it can open multiple connections and grab them at the same time. This had another big impact on speed, especially on first run if there are a lot of feeds or unread articles. I've also updated the progress counts again so it's even smoother (updating over the feed grabs in first runs, etc)